### PR TITLE
added >25 triggers support

### DIFF
--- a/commands/trigger.js
+++ b/commands/trigger.js
@@ -6,7 +6,8 @@ or the entire server.
 -------------- DO NOT EDIT BELOW THIS LINE ----------------*/
 
 const { SlashCommandBuilder } = require('@discordjs/builders');
-const { MessageEmbed, Permissions } = require('discord.js')
+const { MessageEmbed, Permissions } = require('discord.js');
+const helper = require('../modules/helper');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -19,6 +20,7 @@ module.exports = {
             .addChoice('Add', 'add')
             .addChoice('Remove', "remove")
             .addChoice('View', 'view')
+            .addChoice('Clear', 'clear')
         )
         .addChannelOption(option =>
             option.setName('channel')
@@ -94,7 +96,7 @@ module.exports = {
                             embeds: [embed],
                             ephemeral: true
                         });
-                    } else if (guildProfile.triggers.length < 25) {
+                    } else if (guildProfile.triggers.length < 9) {
                         let embed = new MessageEmbed()
                             .setTitle(`Triggers for ${interaction.guild.name}`)
                             .setDescription("All active triggers are listed below")
@@ -109,6 +111,8 @@ module.exports = {
                             embeds: [embed],
                             ephemeral: true
                         });
+                    } else if (guildProfile.triggers.length > 9) {
+                        await helper.displayAllTriggers(interaction, guildProfile.triggers);
                     }
                 } else {
                     let embed = new MessageEmbed()
@@ -128,6 +132,8 @@ module.exports = {
                         ephemeral: true
                     });
                 }
+            } else if (action === 'clear') {
+                await helper.clearAllTriggers(interaction, guildProfile);
             }
         }
     },

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -26,21 +26,23 @@ module.exports = {
         } catch (err) {
             console.error(err);
         }
+        if (channelTriggers.length === 0 || message.author.bot) {
+            return
+        } else {
 
-        if (!channelTriggers || message.author.bot) return;
+            for (channelTrigg of channelTriggers) {
+                if (channelTrigg.keyword.toLowerCase() === message.content.toLowerCase()) {
+                    try {
+                        let member = message.guild.members.cache.find(member => member.id === message.author.id)
 
-        for (channelTrigg of channelTriggers) {
-            if (channelTrigg.keyword.toLowerCase() === message.content.toLowerCase()) {
-                try {
-                    let member = message.guild.members.cache.find(member => member.id === message.author.id)
-
-                    await member.roles.add(channelTrigg.roleAdd)
-                    await member.roles.remove(channelTrigg.roleRemove)
-                } catch (err) {
-                    console.error(err)
+                        await member.roles.add(channelTrigg.roleAdd)
+                        await member.roles.remove(channelTrigg.roleRemove)
+                    } catch (err) {
+                        console.error(err)
+                    }
                 }
             }
+            return message.delete();
         }
-        return message.delete();
     },
 };

--- a/modules/helper.js
+++ b/modules/helper.js
@@ -1,0 +1,147 @@
+const { MessageEmbed, MessageActionRow, MessageButton } = require('discord.js');
+const guildSchema = require('../models/guildSchema');
+
+exports.displayAllTriggers = async function(interaction, triggers) {
+    let totalPages = Math.floor(triggers.length / 9);
+    let pages = [];
+    let cTriggers = chunk(triggers, 9)
+
+    if (triggers.length > 9 && totalPages <= 1) {
+        totalPages = 2
+    }
+
+    function chunk(arr, chunkSize) {
+        if (chunkSize <= 0) throw "Invalid chunk size";
+        var R = [];
+        for (var i = 0, len = arr.length; i < len; i += chunkSize)
+            R.push(arr.slice(i, i + chunkSize));
+        return R;
+    };
+    let index = 0
+    let n = 1
+    while (index < totalPages) {
+        let embed = new MessageEmbed()
+            .setTitle(`Triggers for ${interaction.guild.name}`)
+            .setColor(interaction.guild.me.displyHexColor)
+            .setFooter(`Page ${n} of ${totalPages}`)
+        pages.push(embed);
+        index++
+        n++
+    };
+    let v = 0
+    for (pag of pages) {
+        for (cTrigg of cTriggers[v]) {
+            pag.addField(`\` Keyword: ${cTrigg.keyword}\``, `**Channel:** <#${cTrigg.channel}> \n**RoleRemove:** <@&${cTrigg.roleRemove}> \n**RoleAdd:** <@&${cTrigg.roleAdd}>`, true)
+        }
+        v++
+    }
+    let row = new MessageActionRow()
+        .addComponents(
+            new MessageButton()
+            .setStyle('SECONDARY')
+            .setLabel("<<")
+            .setCustomId('back'),
+            new MessageButton()
+            .setStyle('DANGER')
+            .setLabel("Close")
+            .setCustomId('close'),
+            new MessageButton()
+            .setStyle('SECONDARY')
+            .setLabel('>>')
+            .setCustomId('forward')
+        )
+    await interaction.reply("All Triggers for this server are displayed below.")
+    let m = await interaction.channel.send({
+        embeds: [pages[0]],
+        components: [row],
+        fetchReply: true
+    });
+    let curPage = 1
+
+    const collector = m.createMessageComponentCollector({ componentType: 'BUTTON', time: 900000 });
+
+    collector.on('collect', i => {
+        if (i.user.id === interaction.user.id) {
+            if (i.customId === 'forward') {
+                if (curPage < pages.length) {
+                    m.edit({ embeds: [pages[curPage]] })
+                    curPage++
+                    i.deferUpdate();
+                } else if (curPage >= pages.length + 1) {
+                    i.deferUpdate();
+                }
+            } else if (i.customId === 'back') {
+                if (curPage > 1) {
+                    m.edit({ embeds: [pages[curPage - 2]] })
+                    curPage--
+                    i.deferUpdate();
+                } else if (curPage <= 1) {
+                    i.deferUpdate();
+                }
+            } else if (i.customId === 'close') {
+                return m.delete()
+            }
+        } else {
+            i.reply({ content: `These buttons aren't for you!`, ephemeral: true });
+        }
+    });
+
+    collector.on('end', collected => {
+        return
+    });
+};
+
+exports.clearAllTriggers = async function(interaction, guildProfile) {
+    let embed = new MessageEmbed()
+        .setTitle("Warning!")
+        .setDescription("What you are about to do is irreversible.")
+        .setColor("RED")
+        .addField('Are you Sure?', "Please confirm below that you want to delete **ALL** triggers for this server.", false)
+
+    let row = new MessageActionRow()
+        .addComponents(
+            new MessageButton()
+            .setStyle("DANGER")
+            .setLabel('Yes, Delete')
+            .setCustomId('delete'),
+            new MessageButton()
+            .setStyle('SECONDARY')
+            .setLabel("No, Don't Delete")
+            .setCustomId('dont-delete')
+        )
+
+    let m = await interaction.reply({
+        embeds: [embed],
+        components: [row],
+        fetchReply: true
+    });
+
+    const collector = m.createMessageComponentCollector({ componentType: 'BUTTON', time: 900000 });
+
+    collector.on('collect', i => {
+        if (i.user.id === interaction.user.id) {
+            if (i.customId === 'delete') {
+                guildProfile.triggers = []
+                guildProfile.save();
+                return interaction.followUp({
+                    content: "Successfully removed all triggers from the server."
+                }).then(() => {
+                    return m.delete()
+                });
+            } else if (i.customId === 'dont-delete') {
+                return interaction.followUp({
+                    content: "Canceled, Triggers were not deleted."
+                }).then(() => {
+                    return m.delete()
+                });
+            };
+        } else {
+            i.reply({ content: `These buttons aren't for you!`, ephemeral: true });
+        }
+    });
+
+    collector.on('end', collected => {
+        return
+    });
+
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "mongoose": ">=6.0.11",
         "discordjs": ">=13.2.0",
         "discord-api-types": ">=0.24.0",
-        "@discordjs/rest": ">=0.1.0-canary.0",
+        "@discordjs/rest": ">=0.1.0-canary.0"
     },
-    "run": "npm install mongoose discord.js discord-api-types @discordjs/rest",
+    "run": "npm install mongoose discord.js discord-api-types @discordjs/rest"
 }


### PR DESCRIPTION
#3 Resolution 

- Added Paginated menu for displaying triggers when the trigger count for a server is >9 || > 25.
- Added ability to clear all triggers in a server with a confirmation message, just in case.
- Fixed issue with bot deleting messages from channels where no triggers are set. Will now only delete messages in channels that triggers are set in. (Will probably add the option for enabling/disabling message deletion in trigger channels eventually.)